### PR TITLE
introduce `getPageHead`, full `PageContext` to `getQueryVariables`

### DIFF
--- a/.changeset/sixty-parents-explode.md
+++ b/.changeset/sixty-parents-explode.md
@@ -2,4 +2,9 @@
 "vilay": patch
 ---
 
-add new `getPageHead`. BREAKING CHANGE: for the new `getPageHead` and `getQueryVariables` we provide the full `pageContext`. use `getQueryVariables: ({ routeParams })` instead of `getQueryVariables: (routeParams)`. see the docs for more info!
+add new `getPageHead`. BREAKING CHANGE: replace `head` new `getPageHead()` method. For this and also now to `getQueryVariables` we provide the full `pageContext`, which is another breaking change. 
+
+- `getQueryVariables: ({ routeParams })` instead of `getQueryVariables: (routeParams)`. 
+- `getPageHead: () => ({ title: "My Site" })` instead of `head: { title: "My Site" }` 
+
+see the docs for more info!

--- a/.changeset/sixty-parents-explode.md
+++ b/.changeset/sixty-parents-explode.md
@@ -1,0 +1,5 @@
+---
+"vilay": minor
+---
+
+add new `getPageHead`. BREAKING CHANGE: for the new `getPageHead` and `getQueryVariables` we provide the full `pageContext`. use `getQueryVariables: ({ routeParams })` instead of `getQueryVariables: (routeParams)`. see the docs for more info!

--- a/.changeset/sixty-parents-explode.md
+++ b/.changeset/sixty-parents-explode.md
@@ -1,5 +1,5 @@
 ---
-"vilay": minor
+"vilay": patch
 ---
 
 add new `getPageHead`. BREAKING CHANGE: for the new `getPageHead` and `getQueryVariables` we provide the full `pageContext`. use `getQueryVariables: ({ routeParams })` instead of `getQueryVariables: (routeParams)`. see the docs for more info!

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
     "packages/*"
   ],
   "scripts": {
+    "build": "pnpm --filter vilay --filter render -r build",
+    "postinstall": "pnpm build",
     "lint": "eslint . --ext .ts,.tsx",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,astro}\"",
     "release": "changeset publish"

--- a/package.json
+++ b/package.json
@@ -4,8 +4,6 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "pnpm --filter vilay --filter render -r build",
-    "postinstall": "pnpm build",
     "lint": "eslint . --ext .ts,.tsx",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,astro}\"",
     "release": "changeset publish"

--- a/packages/docs/src/pages/en/page-exports/basic.md
+++ b/packages/docs/src/pages/en/page-exports/basic.md
@@ -28,9 +28,7 @@ export const PageLayout = ({
   return (
     <>
       {routeTransitioning && 'Loading...'}
-      <Suspense fallback="Loading...">
-        {children}
-      </Suspense>
+      <Suspense fallback="Loading...">{children}</Suspense>
     </>
   )
 }
@@ -52,4 +50,29 @@ export const head = {
     description: 'App built with Vilay',
   },
 }
+```
+
+## `getPageHead`
+
+A dynamic equivalent of `head` module
+This method provides the full page context so that you can construct head tags from full page context before the stream is initiated
+
+Expects a return object like above
+
+```tsx
+// /@location/index.page.js
+import { graphql, usePreloadedQuery } from 'react-relay'
+import ItemsList from '../../components/ItemsList'
+
+export const getPageHead = ({ routeParams, urlParsed }) => {
+  const firstVisit = urlParsed?.search?.firstVisit
+
+  return {
+    title: firstVisit
+        ? `Welcome to ${routeParams.location}!`
+        : `Welcome back to ${routeParams.location}!`,
+    },
+  }
+}
+
 ```

--- a/packages/docs/src/pages/en/page-exports/relay.md
+++ b/packages/docs/src/pages/en/page-exports/relay.md
@@ -73,7 +73,7 @@ export const Page = ({ queryRef }) => {
 
 While using Relay, it's pretty common to pass query variables for fetching data.
 Vilay provides `getQueryVariables` to let users return variables to use.
-It receives page context such as [route parameters](https://vite-plugin-ssr.com/filesystem-routing) which can be used to figure out the right query variables.
+It receives [page context](https://vite-plugin-ssr.com/pageContext) such as [route parameters](https://vite-plugin-ssr.com/filesystem-routing) which can be used to figure out the right query variables.
 
 ```tsx
 // /@category/index.page.js

--- a/packages/docs/src/pages/en/page-exports/relay.md
+++ b/packages/docs/src/pages/en/page-exports/relay.md
@@ -73,14 +73,14 @@ export const Page = ({ queryRef }) => {
 
 While using Relay, it's pretty common to pass query variables for fetching data.
 Vilay provides `getQueryVariables` to let users return variables to use.
-It receives [route parameters](https://vite-plugin-ssr.com/filesystem-routing) which can be used to figure out the right query variables.
+It receives page context such as [route parameters](https://vite-plugin-ssr.com/filesystem-routing) which can be used to figure out the right query variables.
 
 ```tsx
 // /@category/index.page.js
 import { graphql, usePreloadedQuery } from 'react-relay'
 import ItemsList from '../../components/ItemsList'
 
-export const getQueryVariables = (routeParams) => ({
+export const getQueryVariables = ({ routeParams }) => ({
   ...routeParams,
   first: 10,
 })

--- a/packages/example/pages/repo/@owner/@name/issues/index.page.tsx
+++ b/packages/example/pages/repo/@owner/@name/issues/index.page.tsx
@@ -17,7 +17,7 @@ interface RouteParams {
   name: string
 }
 
-// Variables used in this query is constructed using the `getQueryVariables()` on preload.
+// Variables used in this query are constructed using the `getQueryVariables()` on preload.
 export const query = graphql`
   query issuesPageQuery(
     $owner: String!
@@ -37,15 +37,23 @@ export default defineVilay<{
   RouteParams: RouteParams
   QueryVariables: issuesPageQuery$variables
 }>({
-  // This overrides the application-wide <head> tag definition in `_default.page.tsx`
-  head: { ...defaultDefines.head, title: 'Issues: Vite SSR app' },
+  query,
   // If a page has `getQueryVariables` exported, it'll be called to get the variables used for preloading the query.
   // If it's not exported, route params will be directly used as variables.
-  getQueryVariables: (routeParams) => ({
-    ...routeParams,
-    first: 10,
-    filter: {},
-  }),
+  getQueryVariables: ({ routeParams, urlParsed }) => {
+    return {
+      ...routeParams,
+      first: urlParsed?.search?.first ? parseInt(urlParsed?.search?.first) : 10,
+      filter: {},
+    }
+  },
+  // This overrides the application-wide <head> tag definition in `_default.page.tsx`
+  getPageHead: ({ routeParams }) => {
+    return {
+      ...defaultDefines.head,
+      title: `Issues for ${routeParams.owner}/${routeParams.name}`
+    }
+  },
   // Relay pagination example.
   Page: ({ queryRef }) => {
     const data = usePreloadedQuery<issuesPageQuery>(query, queryRef)

--- a/packages/example/pages/repo/@owner/@name/issues/index.page.tsx
+++ b/packages/example/pages/repo/@owner/@name/issues/index.page.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { graphql, usePreloadedQuery, type PreloadedQuery } from 'react-relay'
 import { defineVilay } from 'vilay'
-import defaultDefines from '../../../../../renderer/_default.page'
 import IssueListComponent from '../../../../../components/issues/IssueList'
 import type {
   issuesPageQuery,
@@ -50,7 +49,6 @@ export default defineVilay<{
   // This overrides the application-wide <head> tag definition in `_default.page.tsx`
   getPageHead: ({ routeParams }) => {
     return {
-      ...defaultDefines.head,
       title: `Issues for ${routeParams.owner}/${routeParams.name}`
     }
   },

--- a/packages/example/renderer/_default.page.tsx
+++ b/packages/example/renderer/_default.page.tsx
@@ -10,10 +10,10 @@ export default defineVilay({
   // Application-wide <head> tags
   // Meta tags are inserted as <meta name="${KEY}" content="${VALUE}">.
   // Other tags are inserted as <${KEY}>${VALUE}</${KEY}>.
-  head: {
+  getPageHead: () => ({
     title: 'Vite SSR app',
     meta: {
       description: 'App using Vite + vite-plugin-ssr',
-    },
-  },
+    }
+  }),
 })

--- a/packages/vilay/renderer/_default.page.client.tsx
+++ b/packages/vilay/renderer/_default.page.client.tsx
@@ -21,7 +21,7 @@ export async function render(
     Page,
     redirectTo,
     isHydration,
-    exports: { initRelayEnvironment, head, getPageHead },
+    exports: { initRelayEnvironment, getPageHead },
   } = pageContext
 
   if (redirectTo) return navigate(redirectTo)
@@ -39,15 +39,10 @@ export async function render(
   routeManager ??= new RouteManager()
   routeManager.setPage(Page, relayQueryRef)
 
-  let finalHead = head;
 
-  if(getPageHead) {
-    finalHead = getPageHead(pageContext)
-  }
-
-  if (finalHead && !isHydration) {
+  if (getPageHead && !isHydration) {
     const headTags: HTMLElement[] = []
-    for (const [tag, value] of Object.entries(finalHead)) {
+    for (const [tag, value] of Object.entries(getPageHead(pageContext))) {
       if (tag === 'meta') {
         for (const [name, content] of Object.entries(value)) {
           const node = document.createElement('meta')

--- a/packages/vilay/renderer/_default.page.client.tsx
+++ b/packages/vilay/renderer/_default.page.client.tsx
@@ -21,7 +21,7 @@ export async function render(
     Page,
     redirectTo,
     isHydration,
-    exports: { initRelayEnvironment, head },
+    exports: { initRelayEnvironment, head, getPageHead },
   } = pageContext
 
   if (redirectTo) return navigate(redirectTo)
@@ -39,9 +39,15 @@ export async function render(
   routeManager ??= new RouteManager()
   routeManager.setPage(Page, relayQueryRef)
 
-  if (head && !isHydration) {
+  let finalHead = head;
+
+  if(getPageHead) {
+    finalHead = getPageHead(pageContext)
+  }
+
+  if (finalHead && !isHydration) {
     const headTags: HTMLElement[] = []
-    for (const [tag, value] of Object.entries(head)) {
+    for (const [tag, value] of Object.entries(finalHead)) {
       if (tag === 'meta') {
         for (const [name, content] of Object.entries(value)) {
           const node = document.createElement('meta')

--- a/packages/vilay/renderer/_default.page.server.tsx
+++ b/packages/vilay/renderer/_default.page.server.tsx
@@ -24,10 +24,14 @@ export async function render(pageContext: PageContextBuiltIn & PageContext) {
     }
   }
 
+  const head = exports?.getPageHead
+    ? exports?.getPageHead(pageContext)
+    : exports?.head
+
   const headTags: string[] = []
 
-  if (exports.head) {
-    for (const [tag, value] of Object.entries(exports.head)) {
+  if (head) {
+    for (const [tag, value] of Object.entries(head)) {
       if (tag === 'meta') {
         for (const [name, content] of Object.entries(value)) {
           headTags.push(`<meta name="${name}" content="${content}">`)

--- a/packages/vilay/renderer/_default.page.server.tsx
+++ b/packages/vilay/renderer/_default.page.server.tsx
@@ -24,14 +24,12 @@ export async function render(pageContext: PageContextBuiltIn & PageContext) {
     }
   }
 
-  const head = exports?.getPageHead
-    ? exports?.getPageHead(pageContext)
-    : exports?.head
-
   const headTags: string[] = []
 
-  if (head) {
-    for (const [tag, value] of Object.entries(head)) {
+  if (exports.getPageHead) {
+    for (const [tag, value] of Object.entries(
+      exports.getPageHead(pageContext)
+    )) {
       if (tag === 'meta') {
         for (const [name, content] of Object.entries(value)) {
           headTags.push(`<meta name="${name}" content="${content}">`)

--- a/packages/vilay/renderer/_default.page.tsx
+++ b/packages/vilay/renderer/_default.page.tsx
@@ -1,7 +1,6 @@
 export const customExports = [
   'PageLayout',
   'initRelayEnvironment',
-  'head',
   'query',
   'getQueryVariables',
   'getPageHead'

--- a/packages/vilay/renderer/_default.page.tsx
+++ b/packages/vilay/renderer/_default.page.tsx
@@ -4,4 +4,5 @@ export const customExports = [
   'head',
   'query',
   'getQueryVariables',
+  'getPageHead'
 ]

--- a/packages/vilay/renderer/preloadQuery.ts
+++ b/packages/vilay/renderer/preloadQuery.ts
@@ -16,7 +16,7 @@ export default (
     loadQuery(
       relayEnvironment,
       query,
-      getQueryVariables?.(routeParams) ?? routeParams
+      getQueryVariables?.(pageContext) ?? routeParams
     )
   )
 }

--- a/packages/vilay/types.ts
+++ b/packages/vilay/types.ts
@@ -2,7 +2,9 @@ import type React from 'react'
 import type { Environment, GraphQLTaggedNode, Variables } from 'relay-runtime'
 import type { RecordMap } from 'relay-runtime/lib/store/RelayStoreTypes'
 
-export type PageContext = {
+import type { PageContextUrls } from 'vite-plugin-ssr/dist/cjs/shared/addComputedUrlProps'
+
+export type PageContext<T = Record<string, unknown>, V = unknown> = {
   Page?: Page
   userAgent?: string
   cookies?: Record<string, string>
@@ -13,12 +15,13 @@ export type PageContext = {
     pageLayout?: React.FC<PageLayoutProps>
     head?: HeadExports
     query?: GraphQLTaggedNode
-    getQueryVariables: GetQueryVariables<unknown, Variables>
+    getQueryVariables: GetQueryVariables<T, V>
+    getPageHead?: GetPageHead<T>
   }
-  routeParams: Record<string, unknown>
+  routeParams: T
   fetch: typeof fetch
   relayInitialData: RecordMap
-}
+} & PageContextUrls
 
 export type Page<Props = Record<string, unknown>> = React.FC<Props>
 
@@ -29,9 +32,11 @@ export type HeadExports = {
   } & Record<string, unknown>
 } & Record<string, unknown>
 
-export type GetQueryVariables<RouteParams, Variables> = (
-  routeParams: RouteParams
+export type GetQueryVariables<T, V> = (
+  pageContext: PageContext<T, V>
 ) => Variables
+
+export type GetPageHead<T> = (pageContext: PageContext<T>) => HeadExports
 
 export type PageLayoutProps = {
   children: React.ReactNode
@@ -49,15 +54,40 @@ export const defineVilay = <
     RouteParams?: unknown
     QueryVariables?: Variables
   } = {
-    PageProps: Record<string, never>,
-    RouteParams: Record<string, never>,
+    PageProps: Record<string, never>
+    RouteParams: Record<string, never>
     QueryVariables: Variables
   }
 >(pageExports: {
   PageLayout?: React.FC<PageLayoutProps>
   initRelayEnvironment?: InitRelayEnvironment
   Page?: Page<T['PageProps']>
+  /**
+   * Specify a static object literal for the `<head>` tag content for this page
+   * Overridden by `getPageHead`.
+   */
   head?: HeadExports
   query?: GraphQLTaggedNode
+  /**
+   * Build the variables for the preloaded relay query from `pageContext`.
+   * 
+   * @example
+   * ```ts
+   * getQueryVariables: ({ routeParams, urlParsed }) => {
+   *  return {
+   *    ...routeParams,
+   *    first: urlParsed?.search?.first ? parseInt(urlParsed?.search?.first) : 10,
+   *    filter: {},
+   *  }
+   *},
+   *```
+   */
   getQueryVariables?: GetQueryVariables<T['RouteParams'], T['QueryVariables']>
+  // TODO: optional typed params for search params would be cool here as well
+  // for anyone who has to implement a faceted search it would be everything!
+  /**
+   * Build the page head tags from page context for the preloaded relay query.
+   * Overrides `head` if defined.
+   */
+  getPageHead?: GetPageHead<T['RouteParams']>
 }) => pageExports

--- a/packages/vilay/types.ts
+++ b/packages/vilay/types.ts
@@ -13,7 +13,6 @@ export type PageContext<T = Record<string, unknown>, V = Variables> = {
     initRelayEnvironment: InitRelayEnvironment
     PageLayout?: React.FC<PageLayoutProps>
     pageLayout?: React.FC<PageLayoutProps>
-    head?: HeadExports
     query?: GraphQLTaggedNode
     getQueryVariables: GetQueryVariables<T, V>
     getPageHead?: GetPageHead<T>

--- a/packages/vilay/types.ts
+++ b/packages/vilay/types.ts
@@ -4,7 +4,7 @@ import type { RecordMap } from 'relay-runtime/lib/store/RelayStoreTypes'
 
 import type { PageContextUrls } from 'vite-plugin-ssr/dist/cjs/shared/addComputedUrlProps'
 
-export type PageContext<T = Record<string, unknown>, V = unknown> = {
+export type PageContext<T = Record<string, unknown>, V = Variables> = {
   Page?: Page
   userAgent?: string
   cookies?: Record<string, string>
@@ -62,11 +62,6 @@ export const defineVilay = <
   PageLayout?: React.FC<PageLayoutProps>
   initRelayEnvironment?: InitRelayEnvironment
   Page?: Page<T['PageProps']>
-  /**
-   * Specify a static object literal for the `<head>` tag content for this page
-   * Overridden by `getPageHead`.
-   */
-  head?: HeadExports
   query?: GraphQLTaggedNode
   /**
    * Build the variables for the preloaded relay query from `pageContext`.


### PR DESCRIPTION
for the new `getPageHead` and `getQueryVariables` we provide the full `pageContext`.

typed parameters are made available for both, more optional typed params to come later perhaps

includes doc and example updates